### PR TITLE
Notifications not marking as read

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -10,7 +10,7 @@ anyio[trio] >=3.2.1,<4.0.0
 PyJWT==2.8.0
 pyyaml >=5.3.1,<7.0.0
 passlib[bcrypt] >=1.7.2,<2.0.0
-inline-snapshot==0.14.0
+inline-snapshot==0.14.0 q64CDJcsOE
 # types
 types-ujson ==5.10.0.20240515
 types-orjson ==3.6.2


### PR DESCRIPTION
Clicking on notifications does not mark them as read, causing the notification count to remain unchanged.